### PR TITLE
Fix setup.py to match Python 3.12 compatibility (onnxruntime 1.17.0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "torch",
         "torchaudio",
         "websockets",
-        "onnxruntime==1.16.0",
+        "onnxruntime==1.17.0",
         "scipy",
         "websocket-client",
         "numba",


### PR DESCRIPTION
This pull request fixes #337 by updating setup.py to require onnxruntime==1.17.0, resolving installation issues on Python 3.12.

The repository was already updated for Python 3.12 compatibility, but setup.py still required an outdated version (1.16.0), preventing installation.

Steps to reproduce the issue:
```sh
pip install whisper-live==0.6.2
```
or
```sh
git clone https://github.com/OWNER/whisper-live.git
cd whisper-live
pip install .
```
After this change, installation works correctly.
